### PR TITLE
No exception when name registered without transient

### DIFF
--- a/Neleus.DependencyInjection.Extensions.Tests/ServiceByNameFactoryTests.cs
+++ b/Neleus.DependencyInjection.Extensions.Tests/ServiceByNameFactoryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -142,6 +143,99 @@ namespace Neleus.DependencyInjection.Extensions.Tests
                         break;
                 }
             }
+
+        }
+
+
+        [TestMethod]
+        public void MissingTransientByType()
+        {
+            _container.AddTransient<HashSet<int>>();
+
+            _container.AddByName<IEnumerable<int>>(new NameBuilderSettings()
+            {
+                CaseInsensitiveNames = true
+            })
+            .Add("list", typeof(List<int>))
+            .Add("hashSet", typeof(HashSet<int>))
+            .Build();
+
+            var serviceProvider = _container.BuildServiceProvider();
+
+            var serviceByNameFactory = serviceProvider.GetService<IServiceByNameFactory<IEnumerable<int>>>();
+
+            var commandInstance = serviceByNameFactory.GetByName("list");
+
+            Assert.IsNull(commandInstance);
+        }
+
+        [TestMethod]
+        public void MissingTransientByTypeRequired()
+        {
+            _container.AddTransient<HashSet<int>>();
+
+            _container.AddByName<IEnumerable<int>>(new NameBuilderSettings()
+            {
+                CaseInsensitiveNames = true
+            })
+            .Add("list", typeof(List<int>))
+            .Add("hashSet", typeof(HashSet<int>))
+            .Build();
+
+
+            var serviceProvider = _container.BuildServiceProvider();
+
+            var serviceByNameFactory = serviceProvider.GetService<IServiceByNameFactory<IEnumerable<int>>>();
+
+            Assert.ThrowsException<InvalidOperationException>(() =>
+            {
+                var commandInstance = serviceByNameFactory.GetRequiredByName("list");
+            });
+
+        }
+
+        [TestMethod]
+        public void MissingTransientByObject()
+        {
+            _container.AddTransient<HashSet<int>>();
+
+            _container.AddByName<IEnumerable<int>>(new NameBuilderSettings()
+            {
+                CaseInsensitiveNames = true
+            })
+            .Add<List<int>>("list")
+            .Add<HashSet<int>>("hashSet")
+            .Build();
+
+            var serviceProvider = _container.BuildServiceProvider();
+
+            var serviceByNameFactory = serviceProvider.GetService<IServiceByNameFactory<IEnumerable<int>>>();
+
+            var commandInstance = serviceByNameFactory.GetByName("list");
+
+            Assert.IsNull(commandInstance);
+        }
+        [TestMethod]
+        public void MissingTransientByObjectRequired()
+        {
+            _container.AddTransient<HashSet<int>>();
+
+            _container.AddByName<IEnumerable<int>>(new NameBuilderSettings()
+            {
+                CaseInsensitiveNames = true
+            })
+            .Add<List<int>>("list")
+            .Add<HashSet<int>>("hashSet")
+            .Build();
+
+            var serviceProvider = _container.BuildServiceProvider();
+
+            var serviceByNameFactory = serviceProvider.GetService<IServiceByNameFactory<IEnumerable<int>>>();
+
+            Assert.ThrowsException<InvalidOperationException>(() =>
+            {
+                var commandInstance = serviceByNameFactory.GetRequiredByName("list");
+            });
 
         }
     }

--- a/Neleus.DependencyInjection.Extensions/IServiceByNameFactory.cs
+++ b/Neleus.DependencyInjection.Extensions/IServiceByNameFactory.cs
@@ -12,6 +12,7 @@ namespace Neleus.DependencyInjection.Extensions
         /// Provides instance of registered service by name
         /// </summary>
         TService GetByName(string name);
+        TService GetRequiredByName(string name);
         ICollection<string> GetNames();
     }
 }

--- a/Neleus.DependencyInjection.Extensions/IServiceByNameFactory.cs
+++ b/Neleus.DependencyInjection.Extensions/IServiceByNameFactory.cs
@@ -12,7 +12,11 @@ namespace Neleus.DependencyInjection.Extensions
         /// Provides instance of registered service by name
         /// </summary>
         TService GetByName(string name);
-
+        /// <summary>
+        /// Provide instance of registered service by name.  If type isn't registered an InvalidOperationException will be thrown.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
         TService GetRequiredByName(string name);
         /// <summary>
         /// Gets names of all the registered instances of <typeparamref name="TService"/>

--- a/Neleus.DependencyInjection.Extensions/ServiceByNameFactory.cs
+++ b/Neleus.DependencyInjection.Extensions/ServiceByNameFactory.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-
+using Microsoft.Extensions.DependencyInjection;
 namespace Neleus.DependencyInjection.Extensions
 {
     internal class ServiceByNameFactory<TService> : IServiceByNameFactory<TService>
@@ -19,6 +19,12 @@ namespace Neleus.DependencyInjection.Extensions
             if (!_registrations.TryGetValue(name, out var implementationType))
                 throw new ArgumentException($"Service name '{name}' is not registered");
             return (TService)_serviceProvider.GetService(implementationType);
+        }
+        public TService GetRequiredByName(string name)
+        {
+            if (!_registrations.TryGetValue(name, out var implementationType))
+                throw new ArgumentException($"Service name '{name}' is not registered");
+            return (TService)_serviceProvider.GetRequiredService(implementationType);
         }
         public ICollection<string> GetNames()
         {


### PR DESCRIPTION
Fixes #10 
Adds new methods to get service by using GetRequiredService which will throw an exception if the type isn't registered in the service provider.